### PR TITLE
Drain event is not dispatched

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ function duplex(writer, reader) {
 
     reader.on("end", handleEnd)
 
+    writer.on("drain", function() {
+      stream.emit("drain")
+    })
+
     writer.on("error", reemit)
     reader.on("error", reemit)
 


### PR DESCRIPTION
Drain event is not dispatched for result stream causing deadlock.
#2 also started to work for me after this change.
