### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,7 @@
     "tape": "0.3.3",
     "through": "~0.1.4"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Raynos/duplexer/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "node test"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/